### PR TITLE
Allow @CRLF in doc-block instead of strict @LF

### DIFF
--- a/src/SimpleDTO.php
+++ b/src/SimpleDTO.php
@@ -196,7 +196,7 @@ abstract class SimpleDTO implements SimpleDTOContract
             throw new \LogicException('No DTO class property docblocks have been added.');
         }
 
-        preg_match_all('/@property(-read)* (.*?)\n/s', $properties, $annotations);
+        preg_match_all('/@property(-read)* (.*?)\r?\n/s', $properties, $annotations);
 
         if (empty($annotations[2])) {
             throw new \LogicException('No DTO class property docblocks have been added.');


### PR DESCRIPTION
- This change allows the use of both `\n` _and_ ` \r\n` line separators

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phpexpertsinc/simpledto/16)
<!-- Reviewable:end -->
