### PR TITLE
Remove `phpexperts/laravel-env-polyfill` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,10 @@
     "autoload": {
         "psr-4": {
             "PHPExperts\\SimpleDTO\\" : "src/"
-        }
+        },
+        "files": [
+            "src/functions.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": { "PHPExperts\\SimpleDTO\\Tests\\" : "tests/" }

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
         "php": ">=7.2",
         "ext-json": "*",
         "nesbot/carbon": "1.*|2.*",
-        "phpexperts/datatype-validator": "^1.5",
-        "phpexperts/laravel-env-polyfill": "^1.1"
+        "phpexperts/datatype-validator": "^1.5"
     },
     "require-dev": {
         "phpunit/phpunit": "8.*|9.*",

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,45 @@
+<?php
+
+if (! function_exists('class_uses_recursive')) {
+    /**
+     * Returns all traits used by a class, its parent classes and trait of their traits.
+     * Copyright (c) 2018 Taylor Otwell
+     *
+     * @param  object|string  $class
+     * @return array
+     */
+    function class_uses_recursive($class)
+    {
+        if (is_object($class)) {
+            $class = get_class($class);
+        }
+
+        $results = [];
+
+        foreach (array_reverse(class_parents($class)) + [$class => $class] as $class) {
+            $results += trait_uses_recursive($class);
+        }
+
+        return array_unique($results);
+    }
+}
+
+if (! function_exists('trait_uses_recursive')) {
+    /**
+     * Returns all traits used by a trait and its traits.
+     * Copyright (c) 2018 Taylor Otwell
+     *
+     * @param  string  $trait
+     * @return array
+     */
+    function trait_uses_recursive($trait)
+    {
+        $traits = class_uses($trait);
+
+        foreach ($traits as $trait) {
+            $traits += trait_uses_recursive($trait);
+        }
+
+        return $traits;
+    }
+}


### PR DESCRIPTION
**The `phpexperts/laravel-env-polyfill` dependency can cause Laravel 8 TestSuites to fail / operate on wrong config because [server consts defined in `phpunit.xml`](https://github.com/laravel/laravel/blob/a6ca5778391b150102637459ac3b2a42d78d495b/phpunit.xml#L21-L29) are not being applied.**

There is no need for a `env()` polyfill in this package. The only purpose of the dependency is to import `class_uses_recursive()` and `trait_uses_recursive()`. I've copied these functions into the `phpexperts/simple-dto` source to solve the `env()` related issue.

I think the code reuse of `phpexperts/laravel-env-polyfill` does not justify enforcing all users of this package to deal with changes to `env()` behavior. If a user wants these changes he should require `phpexperts/laravel-env-polyfill` directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phpexpertsinc/simpledto/18)
<!-- Reviewable:end -->
