### PR TITLE
Fix nested DTOs where nested array property is an empty array

### DIFF
--- a/src/NestedDTO.php
+++ b/src/NestedDTO.php
@@ -87,7 +87,7 @@ abstract class NestedDTO extends SimpleDTO implements SimpleDTOContract
     private function convertPropertiesToDTOs(array $input, ?array $options): array
     {
         foreach ($this->DTOs as $property => $dtoClass) {
-            if (substr($property, -2) === '[]' || (!empty($input[$property]) && is_array($input[$property]))) {
+            if (substr($property, -2) === '[]' || (array_key_exists($property, $input) && is_array($input[$property]))) {
                 $this->processDTOArray($input, $property, $dtoClass, $options);
 
                 continue;


### PR DESCRIPTION
If a nested DTO has a property defined as an array of another DTO class, but the source data has an empty array for that property, the use of `!empty()` returns false, meaning the `is_array()` check is never reached.
I'm assuming `!empty()` is there to prevent an exception from being thrown by accessing an undefined index of the $Input array, which can also be accomplished by using `array_key_exists()`. The difference is `array_key_exists()` correctly returns true for an empty array, while `!empty()` does not.