### PR TITLE
Version 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v3.6.0
+
+* **[2024-04-26 16:40:51 CDT]** Boosted the requirements to PHP v7.4.
+* **[2024-04-26 17:10:07 CDT]** Completely reimplemented serialization to support PHP 7.4's new __serialize() and for PHP 9.0 support.
+* **[2024-04-26 17:02:39 CDT]** [m] PHPUnit will now display PHP deprecation notices.
+* **[2024-04-26 17:06:54 CDT]** [m] Fixed the MyTypedPropertyTestDTO tests.
+* **[2024-01-30 14:09:31 CDT]** Fixed nested DTOs where nested array property is an empty array. (#25)
+
 ## v3.5.0
 
 * **[2023-07-22 22:40:34 CDT]** Added support for nullable concrete typed properties. HEAD -> v3.5, upstream/v3.5, origin/v3.5

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ PHPExperts\SimpleDTO\NestedDTO
 
 PHPExperts\SimpleDTO\WriteOnceTrait  
  ✔ Can accept null values  
+ ✔ Can be serialized  
  ✔ Will validate on serialize  
  ✔ Will validate on to array  
  ✔ Can write each null value once  

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.4",
         "ext-json": "*",
         "nesbot/carbon": "1.*|2.*",
         "phpexperts/datatype-validator": "^1.5"

--- a/phpunit.v10.xml
+++ b/phpunit.v10.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" colors="true" testdox="true" stopOnError="true" stopOnFailure="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+         testdox="true"
+         stopOnError="true"
+         stopOnFailure="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         cacheDirectory=".phpunit.cache">
   <coverage>
     <report>
       <html outputDirectory="./coverage" lowUpperBound="35" highLowerBound="85"/>

--- a/src/NestedDTO.php
+++ b/src/NestedDTO.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of SimpleDTO, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019-2020 PHP Experts, Inc.
+ * Copyright © 2019-2024 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *   GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *   https://www.phpexperts.pro/
@@ -16,7 +16,6 @@ namespace PHPExperts\SimpleDTO;
 
 use PHPExperts\DataTypeValidator\DataTypeValidator;
 use PHPExperts\DataTypeValidator\InvalidDataTypeException;
-use stdClass;
 
 abstract class NestedDTO extends SimpleDTO implements SimpleDTOContract
 {
@@ -63,27 +62,6 @@ abstract class NestedDTO extends SimpleDTO implements SimpleDTOContract
     /**
      * @return false|string
      */
-    public function serialize()
-    {
-        $output = json_decode((string)parent::serialize(), true);
-        $output['DTOs'] = $this->DTOs;
-
-        return json_encode($output, JSON_PRETTY_PRINT);
-    }
-
-    /**
-     * @param string $serialized
-     */
-    public function unserialize($serialized): void
-    {
-        $decoded = json_decode($serialized, true);
-        $this->DTOs = $decoded['DTOs'];
-        $decoded['data'] = $this->convertPropertiesToDTOs($decoded['data'], $decoded['options']);
-
-        $validator = new DataTypeValidator(new $decoded['isA']());
-        $this->__construct($decoded['data'], $decoded['DTOs'], $decoded['options'], $validator);
-    }
-
     private function convertPropertiesToDTOs(array $input, ?array $options): array
     {
         foreach ($this->DTOs as $property => $dtoClass) {

--- a/src/SimpleDTO.php
+++ b/src/SimpleDTO.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of SimpleDTO, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019-2020 PHP Experts, Inc.
+ * Copyright © 2019-2024 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *   GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *   https://www.phpexperts.pro/
@@ -412,34 +412,6 @@ abstract class SimpleDTO implements SimpleDTOContract
     /**
      * @return false|string
      */
-    public function serialize()
-    {
-        $output = [
-            'isA'       => $this->validator->getValidationType(),
-            'options'   => $this->options,
-            'dataRules' => $this->origDataTypeRules,
-            'data'      => $this->toArray(),
-        ];
-
-        return json_encode($output, JSON_PRETTY_PRINT);
-    }
-
-    /**
-     * @param string $serialized
-     */
-    public function unserialize($serialized): void
-    {
-        $input = json_decode($serialized, true);
-
-        $this->validator = new DataTypeValidator(new $input['isA']());
-        $this->options = $input['options'];
-        $this->validator->validate($input['data'], $input['dataRules']);
-        $this->dataTypeRules = $input['dataRules'];
-        $this->origDataTypeRules = $this->dataTypeRules;
-        $this->loadConcreteProperties($input);
-        $this->data = $input['data'];
-    }
-
         /**
          * Returns all traits used by a class, its parent classes and trait of their traits.
          * Copyright (c) 2018 Taylor Otwell
@@ -491,4 +463,26 @@ abstract class SimpleDTO implements SimpleDTOContract
 
             return $traits;
         }
+
+    public function __serialize(): array
+    {
+        return [
+            'isA'       => $this->validator->getValidationType(),
+            'options'   => $this->options,
+            'dataRules' => $this->origDataTypeRules,
+            'data'      => $this->data,
+        ];
+    }
+
+    public function __unserialize(array $input): void
+    {
+        $this->validator = new DataTypeValidator(new $input['isA']());
+        $this->options = $input['options'];
+        $this->validator->validate($input['data'], $input['dataRules']);
+        $this->dataTypeRules = $input['dataRules'];
+        $this->origDataTypeRules = $this->dataTypeRules;
+        $this->loadConcreteProperties($input);
+        $this->data = $input['data'];
+    }
+
 }

--- a/src/SimpleDTOContract.php
+++ b/src/SimpleDTOContract.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of SimpleDTO, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019-2020 PHP Experts, Inc.
+ * Copyright © 2019-2024 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *   GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *   https://www.phpexperts.pro/
@@ -15,9 +15,8 @@
 namespace PHPExperts\SimpleDTO;
 
 use JsonSerializable;
-use Serializable;
 
-interface SimpleDTOContract extends JsonSerializable, Serializable
+interface SimpleDTOContract extends JsonSerializable
 {
     public function isPermissive(): bool;
 
@@ -47,10 +46,7 @@ interface SimpleDTOContract extends JsonSerializable, Serializable
     /**
      * @return false|string
      */
-    public function serialize();
+    public function __serialize(): array;
 
-    /**
-     * @param string $serialized
-     */
-    public function unserialize($serialized): void;
+    public function __unserialize(array $serialized): void;
 }

--- a/src/WriteOnce.php
+++ b/src/WriteOnce.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of SimpleDTO, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019-2020 PHP Experts, Inc.
+ * Copyright © 2019-2024 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *   GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *   https://www.phpexperts.pro/
@@ -44,10 +44,10 @@ trait WriteOnce
         return parent::toArray();
     }
 
-    public function serialize()
+    public function __serialize(): array
     {
         $this->validate();
 
-        return parent::serialize();
+        return parent::__serialize();
     }
 }

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-time for PHPV in 7.2 7.3 7.4 8.0 8.1 8.2; do
+time for PHPV in 7.4 8.0 8.1 8.2 8.3; do
     PHP_VERSION=$PHPV composer update
     PHPUNIT_V=''
     if [ $PHPV == '7.2' ]; then

--- a/tests/MyTestDTO.php
+++ b/tests/MyTestDTO.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of SimpleDTO, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019-2020 PHP Experts, Inc.
+ * Copyright © 2019-2024 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *   GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *   https://www.phpexperts.pro/

--- a/tests/MyTypedPropertyTestDTO.php
+++ b/tests/MyTypedPropertyTestDTO.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of SimpleDTO, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019-2020 PHP Experts, Inc.
+ * Copyright © 2019-2024 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *   GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *   https://www.phpexperts.pro/
@@ -14,14 +14,13 @@
 
 namespace PHPExperts\SimpleDTO\Tests;
 
-use PHPExperts\SimpleDTO\NestedDTO;
+namespace PHPExperts\SimpleDTO\Tests;
 
-/**
- * @property string                 $name
- * @property MyTypedPropertyTestDTO $myDTO
- */
-class MyNestedTestDTO extends NestedDTO
+use PHPExperts\SimpleDTO\SimpleDTO;
+
+class MyTypedPropertyTestDTO extends SimpleDTO
 {
-    /** @var string */
-    protected $name = 'Nested';
+    protected string $name;
+    protected float $age;
+    protected int $year;
 }

--- a/tests/NestedDTOTest.php
+++ b/tests/NestedDTOTest.php
@@ -24,7 +24,7 @@ final class NestedDTOTest extends TestCase
 {
     private function buildNestedDTO(): NestedDTO
     {
-        $myDTO = new MyTestDTO([
+        $myDTO = new MyTypedPropertyTestDTO([
             'name' => 'PHP Experts, Inc.',
             'age'  => 7.01,
             'year' => 2019,
@@ -32,9 +32,9 @@ final class NestedDTOTest extends TestCase
 
         try {
             /**
-             * @property MyTestDTO $myDTO
+             * @property MyTypedPropertyTestDTO $myDTO
              */
-            $nestedDTO = new MyNestedTestDTO(['myDTO' => $myDTO], ['myDTO' => MyTestDTO::class]);
+            $nestedDTO = new MyNestedTestDTO(['myDTO' => $myDTO], ['myDTO' => MyTypedPropertyTestDTO::class]);
         } catch (InvalidDataTypeException $e) {
             dd([$e->getReasons(), $e->getTraceAsString()]);
         }
@@ -63,12 +63,12 @@ final class NestedDTOTest extends TestCase
     public function testCanConstructArraysOfNestedDTOs()
     {
         $myDTOs = [
-            new MyTestDTO([
+            new MyTypedPropertyTestDTO([
                 'name' => 'PHP Experts, Inc.',
                 'age'  => 7.01,
                 'year' => 2019,
             ]),
-            new MyTestDTO([
+            new MyTypedPropertyTestDTO([
                 'name' => 'Cheyenne Novosad',
                 'age'  => 22.472,
                 'year' => 1996,
@@ -76,9 +76,9 @@ final class NestedDTOTest extends TestCase
         ];
 
         /**
-         * @property MyTestDTO[] $myDTOs
+         * @property MyTypedPropertyTestDTO[] $myDTOs
          */
-        $nestedDTO = new class(['myDTOs' => $myDTOs], ['myDTOs[]' => MyTestDTO::class]) extends NestedDTO {
+        $nestedDTO = new class(['myDTOs' => $myDTOs], ['myDTOs[]' => MyTypedPropertyTestDTO::class]) extends NestedDTO {
         };
 
         self::assertInstanceOf(NestedDTO::class, $nestedDTO);
@@ -100,7 +100,7 @@ final class NestedDTOTest extends TestCase
     public function testCanRetrieveTheDTOs()
     {
         $myDTOs = [
-            new MyTestDTO([
+            new MyTypedPropertyTestDTO([
                 'name' => 'PHP Experts, Inc.',
                 'age'  => 8.01,
                 'year' => 2020,
@@ -108,12 +108,12 @@ final class NestedDTOTest extends TestCase
         ];
 
         /**
-         * @property MyTestDTO[] $myDTOs
+         * @property MyTypedPropertyTestDTO[] $myDTOs
          */
-        $nestedDTO = new class(['myDTOs' => $myDTOs], ['myDTOs[]' => MyTestDTO::class]) extends NestedDTO {
+        $nestedDTO = new class(['myDTOs' => $myDTOs], ['myDTOs[]' => MyTypedPropertyTestDTO::class]) extends NestedDTO {
         };
 
-        $expected = ['myDTOs[]' => MyTestDTO::class];
+        $expected = ['myDTOs[]' => MyTypedPropertyTestDTO::class];
 
         self::assertSame($expected, $nestedDTO->getDTOs());
     }
@@ -129,9 +129,9 @@ final class NestedDTOTest extends TestCase
             ];
 
             /**
-             * @property MyTestDTO $myDTO
+             * @property MyTypedPropertyTestDTO $myDTO
              */
-            $nestedDTO = new class(['myDTO' => $myDTO], ['myDTO' => MyTestDTO::class]) extends NestedDTO {
+            $nestedDTO = new class(['myDTO' => $myDTO], ['myDTO' => MyTypedPropertyTestDTO::class]) extends NestedDTO {
             };
         } catch (InvalidDataTypeException $e) {
             dd($e->getReasons());
@@ -158,9 +158,9 @@ final class NestedDTOTest extends TestCase
         ];
 
         /**
-         * @property MyTestDTO $myDTO
+         * @property MyTypedPropertyTestDTO $myDTO
          */
-        $nestedDTO = new class(['myDTO' => $myDTO], ['myDTO' => MyTestDTO::class]) extends NestedDTO {
+        $nestedDTO = new class(['myDTO' => $myDTO], ['myDTO' => MyTypedPropertyTestDTO::class]) extends NestedDTO {
         };
 
         $expected = [
@@ -185,9 +185,9 @@ final class NestedDTOTest extends TestCase
         ];
 
         /**
-         * @property MyTestDTO $myDTO
+         * @property MyTypedPropertyTestDTO $myDTO
          */
-        $nestedDTO = new class(['myDTO' => $myDTOInfo], ['myDTO' => MyTestDTO::class]) extends NestedDTO {
+        $nestedDTO = new class(['myDTO' => $myDTOInfo], ['myDTO' => MyTypedPropertyTestDTO::class]) extends NestedDTO {
         };
 
         $expected = [
@@ -232,6 +232,18 @@ final class NestedDTOTest extends TestCase
 
         self::assertSame($expected, $nestedDTO->toArray());
 
+        try {
+            $serialized = serialize($myTypedPropertyDTO);
+            $actual = unserialize($serialized);
+//            dd([
+//                'serialized'   => $serialized,
+//                'unserialized' => $actual
+//            ]);
+        } catch (InvalidDataTypeException $e) {
+            dd($e->getReasons());
+        }
+
+
         $actual = unserialize(serialize($myTypedPropertyDTO));
         self::assertEquals($myTypedPropertyDTO, $actual);
     }
@@ -274,7 +286,7 @@ final class NestedDTOTest extends TestCase
     /** @testdox All registered Nested DTOs are required */
     public function testAllRegisteredNestedDTOsAreRequired()
     {
-        $myDTO = new MyTestDTO([
+        $myDTO = new MyTypedPropertyTestDTO([
             'name' => 'PHP Experts, Inc.',
             'age'  => 7.01,
             'year' => 2019,
@@ -282,15 +294,15 @@ final class NestedDTOTest extends TestCase
 
         try {
             /**
-             * @property MyTestDTO $myDTO
+             * @property MyTypedPropertyTestDTO $myDTO
              */
-            $dto = new class(['myDTO' => $myDTO], ['myDTO' => MyTestDTO::class, 'missing' => MyTestDTO::class]) extends NestedDTO {
+            $dto = new class(['myDTO' => $myDTO], ['myDTO' => MyTypedPropertyTestDTO::class, 'missing' => MyTypedPropertyTestDTO::class]) extends NestedDTO {
             };
 
             $this->fail('A nested DTO was created without all of the required DTOs.');
         } catch (InvalidDataTypeException $e) {
             self::assertSame('Missing critical DTO input(s).', $e->getMessage());
-            self::assertSame(['missing' => MyTestDTO::class], $e->getReasons());
+            self::assertSame(['missing' => MyTypedPropertyTestDTO::class], $e->getReasons());
         }
     }
 
@@ -304,9 +316,9 @@ final class NestedDTOTest extends TestCase
         ];
 
         /**
-         * @property MyTestDTO $myDTO
+         * @property MyTypedPropertyTestDTO $myDTO
          */
-        $dto = new class(['myDTO' => $myDTO, 'extra' => $myDTO], ['myDTO' => MyTestDTO::class]) extends NestedDTO {
+        $dto = new class(['myDTO' => $myDTO, 'extra' => $myDTO], ['myDTO' => MyTypedPropertyTestDTO::class]) extends NestedDTO {
         };
 
         $expectedArray = [
@@ -329,7 +341,7 @@ final class NestedDTOTest extends TestCase
         ];
 
         self::assertSame($expectedArray, $dto->toArray());
-        self::assertInstanceOf(MyTestDTO::class, $dto->myDTO);
+        self::assertInstanceOf(MyTypedPropertyTestDTO::class, $dto->myDTO);
         self::assertInstanceOf('\stdClass', $dto->extra);
         self::assertEquals($expectedObject, $dto->extra);
     }
@@ -413,7 +425,7 @@ JSON;
         $nestedDTO = $this->buildNestedDTO();
         $expected = [
             'name'  => 'Nested',
-            'myDTO' => new MyTestDTO([
+            'myDTO' => new MyTypedPropertyTestDTO([
                 'name' => 'PHP Experts, Inc.',
                 'age'  => 7.01,
                 'year' => 2019,

--- a/tests/NestedDTOTest.php
+++ b/tests/NestedDTOTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of SimpleDTO, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019-2020 PHP Experts, Inc.
+ * Copyright © 2019-2024 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *   GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *   https://www.phpexperts.pro/
@@ -348,45 +348,20 @@ final class NestedDTOTest extends TestCase
 
     private function getSerializedDTO(): string
     {
-        $expectedJSON = <<<'JSON'
-{
-    "isA": "PHPExperts\\DataTypeValidator\\IsAFuzzyDataType",
-    "options": [
-        101
-    ],
-    "dataRules": {
-        "name": "string",
-        "myDTO": "MyTestDTO"
-    },
-    "data": {
-        "name": "Nested",
-        "myDTO": {
-            "name": "PHP Experts, Inc.",
-            "age": 7.01,
-            "year": 2019
-        }
-    },
-    "DTOs": {
-        "myDTO": "PHPExperts\\SimpleDTO\\Tests\\MyTestDTO"
-    }
-}
-JSON;
-
-        return $expectedJSON;
+        return 'O:42:"PHPExperts\SimpleDTO\Tests\MyNestedTestDTO":4:{s:3:"isA";s:45:"PHPExperts\DataTypeValidator\IsAFuzzyDataType";s:7:"options";a:1:{i:0;i:101;}s:9:"dataRules";a:2:{s:4:"name";s:6:"string";s:5:"myDTO";s:22:"MyTypedPropertyTestDTO";}s:4:"data";a:2:{s:4:"name";s:6:"Nested";s:5:"myDTO";O:49:"PHPExperts\SimpleDTO\Tests\MyTypedPropertyTestDTO":4:{s:3:"isA";s:46:"PHPExperts\DataTypeValidator\IsAStrictDataType";s:7:"options";a:0:{}s:9:"dataRules";a:3:{s:4:"name";s:6:"string";s:3:"age";s:5:"float";s:4:"year";s:3:"int";}s:4:"data";a:3:{s:4:"name";s:17:"PHP Experts, Inc.";s:3:"age";d:7.01;s:4:"year";i:2019;}}}}';
     }
 
     public function testCanBeSerialized()
     {
         $nestedDTO = $this->buildNestedDTO();
         $expectedJSON = $this->getSerializedDTO();
-        $serializedJson = sprintf(
-            "%s$expectedJSON}",
-            'C:42:"PHPExperts\SimpleDTO\Tests\MyNestedTestDTO":428:{'
-        );
+        //dd($nestedDTO->toArray());
+        $actualJSON = serialize($nestedDTO);
 
-        self::assertSame($expectedJSON, $nestedDTO->serialize());
+//        file_put_contents("/tmp/expected.json", $expectedJSON);
+//        file_put_contents("/tmp/actual.json", $actualJSON);
 
-        self::assertSame($serializedJson, serialize($nestedDTO));
+        self::assertSame($expectedJSON, $actualJSON);
 
         return $nestedDTO;
     }
@@ -396,13 +371,13 @@ JSON;
      */
     public function testCanBeUnserialized(SimpleDTO $origDTO)
     {
-        $serializedJSON = sprintf(
-            '%s%s}',
-            'C:42:"PHPExperts\SimpleDTO\Tests\MyNestedTestDTO":428:{',
-            $this->getSerializedDTO()
-        );
+        $serialized = $this->getSerializedDTO();
 
-        $awokenDTO = unserialize($serializedJSON);
+        try {
+            $awokenDTO = unserialize($serialized);
+        } catch (InvalidDataTypeException $e) {
+            dd($e->getReasons());
+        }
 
         self::assertEquals(serialize($origDTO), serialize($awokenDTO));
     }

--- a/tests/SimpleDTOTest.php
+++ b/tests/SimpleDTOTest.php
@@ -29,10 +29,15 @@ final class SimpleDTOTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->dto = new MyTestDTO([
-            'name' => 'World',
-            'age'  => 4.51 * 1000000000,
-        ]);
+        try {
+            $this->dto = new MyTypedPropertyTestDTO([
+                'name' => 'World',
+                'age'  => 4.51 * 1000000000,
+                'year' => 1981,
+            ]);
+        } catch (InvalidDataTypeException $t) {
+            dd($t->getReasons());
+        }
 
         parent::setUp();
     }
@@ -40,7 +45,7 @@ final class SimpleDTOTest extends TestCase
     public function testPropertiesAreSetViaTheConstructor()
     {
         self::assertInstanceOf(SimpleDTO::class, $this->dto);
-        self::assertInstanceOf(MyTestDTO::class, $this->dto);
+        self::assertInstanceOf(MyTypedPropertyTestDTO::class, $this->dto);
     }
 
     public function testPropertiesAreAccessedAsPublicProperties()
@@ -217,18 +222,24 @@ final class SimpleDTOTest extends TestCase
         $testNullabbleWithNulls = function () {
             $info = ['firstName' => 'Nataly', 'lastName' => null, 'age' => null, 'height' => null];
 
-            /**
-             * Every public and private property is ignored, as are static protected ones.
-             *
-             * @property ?string $firstName
-             * @property ?string $lastName
-             * @property ?int    $age
-             * @property ?float  $height
-             */
-            $dto = new class($info, [SimpleDTO::PERMISSIVE]) extends SimpleDTO {
-            };
+            try {
+                /**
+                 * Every public and private property is ignored, as are static protected ones.
+                 *
+                 * @property ?string $firstName
+                 * @property ?string $lastName
+                 * @property ?int    $age
+                 * @property ?float  $height
+                 */
+                $dto = new class($info, [SimpleDTO::PERMISSIVE]) extends SimpleDTO {
+                    protected int $year = 1988;
+                };
+            } catch (\Throwable $t) {
+                dd($t->getMessage());
+            }
 
             $expected = [
+                'year'      => 1988,
                 'firstName' => 'Nataly',
                 'lastName'  => null,
                 'age'       => null,

--- a/tests/SimpleDTOTest.php
+++ b/tests/SimpleDTOTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of SimpleDTO, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019-2020 PHP Experts, Inc.
+ * Copyright © 2019-2024 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *   GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *   https://www.phpexperts.pro/
@@ -253,6 +253,11 @@ final class SimpleDTOTest extends TestCase
 
     private function getSerializedDTO(): string
     {
+        return 'O:49:"PHPExperts\SimpleDTO\Tests\MyTypedPropertyTestDTO":4:{s:3:"isA";s:45:"PHPExperts\DataTypeValidator\IsAFuzzyDataType";s:7:"options";a:1:{i:0;i:101;}s:9:"dataRules";a:3:{s:4:"name";s:6:"string";s:3:"age";s:5:"float";s:4:"year";s:3:"int";}s:4:"data";a:3:{s:4:"year";i:2019;s:4:"name";s:5:"World";s:3:"age";s:10:"4510000000";}}';
+    }
+
+    private function getSerializedDTOv1(): array
+    {
         $expectedJSON = <<<'JSON'
 {
     "isA": "PHPExperts\\DataTypeValidator\\IsAFuzzyDataType",
@@ -272,24 +277,20 @@ final class SimpleDTOTest extends TestCase
 }
 JSON;
 
-        return $expectedJSON;
+        return json_decode($expectedJSON, true);
     }
 
     public function testCanBeSerialized()
     {
-        $dto = new MyTestDTO([
+        $dto = new MyTypedPropertyTestDTO([
+            'year' => 2019,
             'name' => 'World',
             'age'  => (string) (4.51 * 1000000000),
         ], [SimpleDTO::PERMISSIVE]);
 
-        $expectedJSON = $this->getSerializedDTO();
-        $serializedJson = sprintf(
-            "%s$expectedJSON}",
-            'C:36:"PHPExperts\SimpleDTO\Tests\MyTestDTO":294:{'
-        );
+        $expected = $this->getSerializedDTO();
 
-        self::assertSame($expectedJSON, $dto->serialize());
-        self::assertSame($serializedJson, serialize($dto));
+        self::assertSame($expected, serialize($dto));
 
         return $dto;
     }
@@ -299,12 +300,7 @@ JSON;
      */
     public function testCanBeUnserialized(SimpleDTO $origDTO)
     {
-        $serializedJSON = sprintf(
-            '%s%s}',
-            'C:36:"PHPExperts\SimpleDTO\Tests\MyTestDTO":294:{',
-            $this->getSerializedDTO()
-        );
-
+        $serializedJSON = $this->getSerializedDTO();
         $awokenDTO = unserialize($serializedJSON);
 
         self::assertEquals($origDTO->toArray(), $awokenDTO->toArray());

--- a/tests/SimpleSadPathsTest.php
+++ b/tests/SimpleSadPathsTest.php
@@ -26,29 +26,31 @@ final class SimpleSadPathsTest extends TestCase
     public function testCannotInitializeWithANonexistingProperty()
     {
         try {
-            new MyTestDTO([
+            new MyTypedPropertyTestDTO([
+                'year'        => 1988,
                 'name'        => 'Sibi',
                 'age'         => 25.2,
                 'nonexistant' => true,
             ]);
             $this->fail('A DTO with an undefined property was created.');
         } catch (Error $e) {
-            self::assertEquals('Undefined property: PHPExperts\SimpleDTO\Tests\MyTestDTO::$nonexistant.', $e->getMessage());
+            self::assertEquals('Undefined property: PHPExperts\SimpleDTO\Tests\MyTypedPropertyTestDTO::$nonexistant.', $e->getMessage());
         }
     }
 
     public function testAccessingANonexistingPropertyThrowsAnError()
     {
         try {
-            $dto = new MyTestDTO([
-                'name'        => 'Sibi',
-                'age'         => 25.2,
+            $dto = new MyTypedPropertyTestDTO([
+                'year'  => 2005,
+                'name'  => 'Sibi',
+                'age'   => 25.2,
             ]);
 
             $dto->doesntExist;
             $this->fail('A non-existing property was accessed.');
         } catch (Error $e) {
-            self::assertEquals('Undefined property: PHPExperts\SimpleDTO\Tests\MyTestDTO::$doesntExist.', $e->getMessage());
+            self::assertEquals('Undefined property: PHPExperts\SimpleDTO\Tests\MyTypedPropertyTestDTO::$doesntExist.', $e->getMessage());
         }
     }
 
@@ -181,7 +183,7 @@ C:36:"PHPExperts\SimpleDTO\Tests\MyTestDTO":291:{{
 JSON;
         $expected = [
             'name' => 'name is not a valid string',
-            'age'  => 'age is not a valid floam',
+            'age'  => 'age is not a valid float',
         ];
 
         try {

--- a/tests/SimpleSadPathsTest.php
+++ b/tests/SimpleSadPathsTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of SimpleDTO, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019-2020 PHP Experts, Inc.
+ * Copyright © 2019-2024 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *   GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *   https://www.phpexperts.pro/
@@ -15,6 +15,7 @@
 namespace PHPExperts\SimpleDTO\Tests;
 
 use Error;
+use InvalidArgumentException;
 use LogicException;
 use PHPExperts\DataTypeValidator\InvalidDataTypeException;
 use PHPExperts\SimpleDTO\SimpleDTO;
@@ -163,31 +164,26 @@ final class SimpleSadPathsTest extends TestCase
     /** @testdox Will not unserialize DTOs with invalid data */
     public function testWillNotUnserializeDTOsWithInvalidData()
     {
-        $serializedJSON = <<<'JSON'
-C:36:"PHPExperts\SimpleDTO\Tests\MyTestDTO":291:{{
-    "isA": "PHPExperts\\DataTypeValidator\\IsAFuzzyDataType",
-    "options": [
-        101
-    ],
-    "dataRules": {
-        "name": "?string",
-        "age": "?floam",
-        "year": "?int"
-    },
-    "data": {
-        "year": 2019,
-        "name": 1,
-        "age": "4510000000"
-    }
-}}
-JSON;
+        // To build, also comment out lines 229-230 in SimpleDTO.php.
+        // $dto = new MyTestDTO([
+        //     'name' => 1,
+        //     'age'  => (string)(4.51 * 1000000000),
+        //     'year' => 1981,
+        // ]);
+        // dd(serialize($dto));
+
+        $serialized = <<<TXT
+O:36:"PHPExperts\SimpleDTO\Tests\MyTestDTO":4:{s:3:"isA";s:46:"PHPExperts\DataTypeValidator\IsAStrictDataType";s:7:"options";a:0:{}s:9:"dataRules";a:3:{s:4:"name";s:6:"string";s:3:"age";s:5:"float";s:4:"year";s:3:"int";}s:4:"data";a:3:{s:4:"name";i:1;s:3:"age";s:10:"4510000000";s:4:"year";i:1981;}}
+TXT;
+
         $expected = [
             'name' => 'name is not a valid string',
             'age'  => 'age is not a valid float',
         ];
 
         try {
-            unserialize($serializedJSON);
+            $data = unserialize($serialized);
+            dump($data);
             $this->fail('Unserialized a DTO with invalid data.');
         } catch (InvalidDataTypeException $e) {
             self::assertSame('There were 2 validation errors.', $e->getMessage());

--- a/tests/WriteOnceTestDTO.php
+++ b/tests/WriteOnceTestDTO.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of SimpleDTO, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019-2024 PHP Experts, Inc.
+ * Copyright © 2024 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *   GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *   https://www.phpexperts.pro/
@@ -14,14 +14,15 @@
 
 namespace PHPExperts\SimpleDTO\Tests;
 
-use PHPExperts\SimpleDTO\NestedDTO;
+use PHPExperts\SimpleDTO\SimpleDTO;
+use PHPExperts\SimpleDTO\WriteOnce;
 
 /**
- * @property string                 $name
- * @property MyTypedPropertyTestDTO $myDTO
+ * @property string $name
+ * @property float  $age
+ * @property int    $year
  */
-class MyNestedTestDTO extends NestedDTO
+class WriteOnceTestDTO extends SimpleDTO
 {
-    /** @var string */
-    protected $name = 'Nested';
+    use WriteOnce;
 }


### PR DESCRIPTION
## v3.6.0

* **[2024-04-26 16:40:51 CDT]** Boosted the requirements to PHP v7.4.
* **[2024-04-26 17:10:07 CDT]** Completely reimplemented serialization to support PHP 7.4's new __serialize() and for PHP 9.0 support.
* **[2024-04-26 17:02:39 CDT]** [m] PHPUnit will now display PHP deprecation notices.
* **[2024-04-26 17:06:54 CDT]** [m] Fixed the MyTypedPropertyTestDTO tests.
* **[2024-01-30 14:09:31 CDT]** Fixed nested DTOs where nested array property is an empty array. (#25)
