### PR TITLE
Version 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v3.7.1
+
+* **[2024-07-09 06:29:19 CDT]** Added support for Carbon 3.x and phpexperts/dockerize v10.x.
+
 ## v3.7.0
 
 * **[2024-06-26 23:23:03 CDT]** Added documentation for WriteOnce.

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=7.4",
         "ext-json": "*",
-        "nesbot/carbon": "1.*|2.*",
+        "nesbot/carbon": "2.*|3.*",
         "phpexperts/datatype-validator": "^1.5"
     },
     "require-dev": {
@@ -31,7 +31,7 @@
         "symfony/var-dumper": "*",
         "povils/phpmnd": "*",
         "squizlabs/php_codesniffer": "*",
-        "phpexperts/dockerize": "*"
+        "phpexperts/dockerize": "^10.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
* **[2024-07-09 06:29:19 CDT]** Added support for Carbon 3.x and phpexperts/dockerize v10.x.