### PR TITLE
Version 3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v3.8.1
+
+* **[2025-03-17 22:01:49 CDT]** Require minimal phpexperts/datatype-validator v1.7.0.
+
 ## v3.8.0
 
 * **[2025-03-13 17:31:31 CDT]** Upgraded to PHPUnit v12 and added attributes for every phpunit @tag.

--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,13 @@
         }
     ],
     "repositories": [
-        {
-            "type": "composer",
-            "url": "https://bettergist.phpexperts.pro/"
-        }
+        { "type": "composer", "url": "https://bettergist.phpexperts.pro/" }
     ],
     "require": {
         "php": ">=7.4",
         "ext-json": "*",
         "nesbot/carbon": "2.*|3.*",
-        "phpexperts/datatype-validator": "^1.5"
+        "phpexperts/datatype-validator": "^1.7"
     },
     "require-dev": {
         "phpunit/phpunit": "8.*|9.*|^10.5.32|11.*|12.*",

--- a/src/SimpleDTO.php
+++ b/src/SimpleDTO.php
@@ -493,5 +493,4 @@ abstract class SimpleDTO implements SimpleDTOContract
         $this->loadConcreteProperties($input);
         $this->data = $input['data'];
     }
-
 }


### PR DESCRIPTION
* **[2025-03-17 22:01:49 CDT]** Require minimal phpexperts/datatype-validator v1.7.0.
    
v1.7.0 is needed for its new support of "mixed" datatype (e.g., no validation).
    
Mixed datatype DTOs are needed for APIs with covariant return types in the same field. This was first encountered in ChatGPT's and other LLM's message APIs, where the content field can be either plaintext (the default) aka "string", or JSON, aka stdobject or NestedDTOs.

See PHPExpertsInc/DataTypeValidator#14.