### PR TITLE
Version 3.9.0: Added support for PHP 8.0-minimal projects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v3.9.0
+
+* **[2025-03-17 22:32:16 CDT]** Version 3.9.0: Added support for PHP 8.0-minimal projects by upgrading to phpexperts/datatype-validator v2.1+.
+
 ## v3.8.1
 
 * **[2025-03-17 22:01:49 CDT]** Require minimal phpexperts/datatype-validator v1.7.0.

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": ">=7.4",
         "ext-json": "*",
         "nesbot/carbon": "2.*|3.*",
-        "phpexperts/datatype-validator": "^1.7"
+        "phpexperts/datatype-validator": "^1.7|^2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "8.*|9.*|^10.5.32|11.*|12.*",


### PR DESCRIPTION
* **[2025-03-17 22:32:16 CDT]** Version 3.9.0: Added support for PHP 8.0-minimal projects by upgrading to phpexperts/datatype-validator v2.1+.