### PR TITLE
Version 3.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v3.9.1
+
+* **[2025-04-17 06:11:37 CDT]** Upgraded to phpexperts/dockerize v13.0.0.
+* **[2025-04-17 06:09:37 CDT]** [m] Fixed the tests.
+* **[2025-04-10 08:44:12 CDT]** Added compatibility with phpexperts/datatype-validator v1.8.0 and v3.0.0.
+
 ## v3.9.0
 
 * **[2025-03-17 22:32:16 CDT]** Version 3.9.0: Added support for PHP 8.0-minimal projects by upgrading to phpexperts/datatype-validator v2.1+.

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ PHPExperts\SimpleDTO\NestedDTO
  ✔ Nested DTOs use Loose typing  
  ✔ Nested DTOs can be built using Typed Properties  
  ✔ Nested DTOs with Typed Properties use Strict typing  
+ ✔ Nested DTOs with extra properties will work with Permissive mode  
  ✔ All registered Nested DTOs are required  
  ✔ Optional, unregistered, Nested DTOs are handled gracefully  
  ✔ Can be serialized  

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": ">=7.4",
         "ext-json": "*",
         "nesbot/carbon": "2.*|3.*",
-        "phpexperts/datatype-validator": "^1.7|^2.1"
+        "phpexperts/datatype-validator": "^1.8|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "8.*|9.*|^10.5.32|11.*|12.*",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "symfony/var-dumper": "*",
         "povils/phpmnd": "^3.6",
         "squizlabs/php_codesniffer": "*",
-        "phpexperts/dockerize": "^12.1"
+        "phpexperts/dockerize": "^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/NestedDTOTest.php
+++ b/tests/NestedDTOTest.php
@@ -18,6 +18,7 @@ use DateTime;
 use PHPExperts\DataTypeValidator\InvalidDataTypeException;
 use PHPExperts\SimpleDTO\NestedDTO;
 use PHPExperts\SimpleDTO\SimpleDTO;
+use PHPExperts\SimpleDTO\SimpleDTOContract;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
@@ -295,14 +296,10 @@ final class NestedDTOTest extends TestCase
         }
     }
 
-    /** @testdox Nested DTOs with Typed Properties use Strict typing */
-    #[TestDox('Nested DTOs with Typed Properties use Strict typing')]
-    public function testNestedDTOsWithExtraPropertiesWillWorkWithPermissiveTyping()
+    /** @testdox Nested DTOs with extra properties will work with Permissive mode */
+    #[TestDox('Nested DTOs with extra properties will work with Permissive mode')]
+    public function testNestedDTOsWithExtraPropertiesWillWorkWithPermissiveMode()
     {
-        if (version_compare(phpversion(), '7.4.0', '<')) {
-            self::markTestSkipped('This functionality requires PHP 7.4 or higher.');
-        }
-
         // Test with Loose Types
         try {
             $myDTOInfo = [
@@ -311,7 +308,9 @@ final class NestedDTOTest extends TestCase
                 'year'  => '2019',
                 'extra' => true,
             ];
-            $myTypedPropertyDTO = new MyTypedPropertyTestDTO($myDTOInfo);
+            $myTypedPropertyDTO = new MyTypedPropertyTestDTO($myDTOInfo, [SimpleDTO::PERMISSIVE]);
+            self::assertInstanceOf(SimpleDTOContract::class, $myTypedPropertyDTO);
+            self::assertInstanceOf(SimpleDTO::class, $myTypedPropertyDTO);
 
             /**
              * @property MyTypedPropertyTestDTO $myDTO
@@ -323,14 +322,11 @@ final class NestedDTOTest extends TestCase
             ) extends NestedDTO {
             };
 
-            self::fail('NestedDTO was built with loose types.');
+            self::assertInstanceOf(SimpleDTOContract::class, $nestedDTO);
+            self::assertInstanceOf(SimpleDTO::class, $nestedDTO);
+            self::assertInstanceOf(NestedDTO::class, $nestedDTO);
         } catch (InvalidDataTypeException $e) {
-            self::assertEquals('There were 1 validation errors.', $e->getMessage());
-            self::assertEquals([
-                    'age' => 'age is not a valid float',
-                ],
-                $e->getReasons()
-            );
+            dd($e->getReasons());
         }
     }
 

--- a/tests/NestedDTOTest.php
+++ b/tests/NestedDTOTest.php
@@ -284,10 +284,50 @@ final class NestedDTOTest extends TestCase
 
             self::fail('NestedDTO was built with loose types.');
         } catch (InvalidDataTypeException $e) {
-            self::assertEquals('There were 2 validation errors.', $e->getMessage());
+            self::assertEquals('There were 3 validation errors.', $e->getMessage());
             self::assertEquals([
-                    'age'  => 'age is not a valid float',
-                    'year' => 'year is not a valid int',
+                    'extra' => "'extra' is not a configured DTO property",
+                    'age'   => 'age is not a valid float',
+                    'year'  => 'year is not a valid int'
+                ],
+                $e->getReasons()
+            );
+        }
+    }
+
+    /** @testdox Nested DTOs with Typed Properties use Strict typing */
+    #[TestDox('Nested DTOs with Typed Properties use Strict typing')]
+    public function testNestedDTOsWithExtraPropertiesWillWorkWithPermissiveTyping()
+    {
+        if (version_compare(phpversion(), '7.4.0', '<')) {
+            self::markTestSkipped('This functionality requires PHP 7.4 or higher.');
+        }
+
+        // Test with Loose Types
+        try {
+            $myDTOInfo = [
+                'name'  => 'PHP Experts, Inc.',
+                'age'   => null,
+                'year'  => '2019',
+                'extra' => true,
+            ];
+            $myTypedPropertyDTO = new MyTypedPropertyTestDTO($myDTOInfo);
+
+            /**
+             * @property MyTypedPropertyTestDTO $myDTO
+             */
+            $nestedDTO = new class(
+                ['myDTO' => $myTypedPropertyDTO],
+                ['myDTO' => MyTypedPropertyTestDTO::class],
+                [SimpleDTO::PERMISSIVE]
+            ) extends NestedDTO {
+            };
+
+            self::fail('NestedDTO was built with loose types.');
+        } catch (InvalidDataTypeException $e) {
+            self::assertEquals('There were 1 validation errors.', $e->getMessage());
+            self::assertEquals([
+                    'age' => 'age is not a valid float',
                 ],
                 $e->getReasons()
             );

--- a/tests/SimpleSadPathsTest.php
+++ b/tests/SimpleSadPathsTest.php
@@ -22,6 +22,7 @@ use PHPExperts\SimpleDTO\SimpleDTO;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
+use Throwable;
 
 /** @testdox SimpleDTO Sad Paths */
 #[TestDox('SimpleDTO Sad Paths')]
@@ -37,8 +38,9 @@ final class SimpleSadPathsTest extends TestCase
                 'nonexistant' => true,
             ]);
             $this->fail('A DTO with an undefined property was created.');
-        } catch (Error $e) {
-            self::assertEquals('Undefined property: PHPExperts\SimpleDTO\Tests\MyTypedPropertyTestDTO::$nonexistant.', $e->getMessage());
+        } catch (InvalidDataTypeException $e) {
+            self::assertEquals('There was 1 validation error.', $e->getMessage());
+            self::assertEquals(['nonexistant' => "'nonexistant' is not a configured DTO property"], $e->getReasons());
         }
     }
 


### PR DESCRIPTION
* **[2025-04-17 06:11:37 CDT]** Upgraded to phpexperts/dockerize v13.0.0.
* **[2025-04-17 06:09:37 CDT]** [m] Fixed the tests.
* **[2025-04-10 08:44:12 CDT]** Added compatibility with phpexperts/datatype-validator v1.8.0 and v3.0.0.

